### PR TITLE
fixing small typo

### DIFF
--- a/src/ui/PageContentsForIndex/AvailableDestinations.tsx
+++ b/src/ui/PageContentsForIndex/AvailableDestinations.tsx
@@ -167,7 +167,7 @@ const AvailableDestinations: React.FunctionComponent<{
       <p>
         Omitting the destination or entering an non-existing one takes you to
         the package page on <ExternalLink href="https://www.npmjs.com" /> as if
-        you React.used&nbsp;<Keyword onClick={handleKeywordClick}>n</Keyword>.
+        you used&nbsp;<Keyword onClick={handleKeywordClick}>n</Keyword>.
       </p>
     </>
   );


### PR DESCRIPTION
I was browsing your main doc/splash page, and I think the `React.` might be a typo (maybe added by an IDE's autocomplete or a script)?