### PR TITLE
feat: add Cache-Control header for faster responses

### DIFF
--- a/pages/api/jump.handler.ts
+++ b/pages/api/jump.handler.ts
@@ -4,6 +4,7 @@ import { resolveDestination } from "../shared/destinations";
 
 const handler: NextApiHandler = async (req, res) => {
   let destinationUrl = "/";
+  let maxAge = 0;
 
   const to = typeof req.query.to === "string" ? req.query.to : "";
 
@@ -18,11 +19,15 @@ const handler: NextApiHandler = async (req, res) => {
 
     if (resolvedDestination.outcome === "success") {
       destinationUrl = resolvedDestination.url;
+      const queryMaxAge = Number(req.query["max-age"]);
+      maxAge = Number.isNaN(queryMaxAge) ? maxAge : queryMaxAge;
     }
   }
 
-  res.writeHead(302, {
+  res.writeHead(301, {
     Location: destinationUrl,
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    "Cache-Control": `public, max-age=${maxAge}, must-revalidate`,
   });
 
   res.end();


### PR DESCRIPTION
Add the header for cache control so user gets faster responses for same search queries.

- By default the `Cache-Control` defaults to default value
- If `max-age` query and destination found, change `Control-Cache` duration
- 301 is required for Vercel cache also to be allowed
- 301 is controlled by `Cache-Control`
- Someone who uses `njt` as search engine, can change it to desirable cache

```md
https://njt.vercel.app/jump?max-age=20&from=chrome&to=%s
```

https://vercel.com/docs/concepts/edge-network/caching#cacheable-responses
https://vercel.com/docs/concepts/edge-network/caching#serverless-functions---lambdas

- [`Cache-Control#public`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#public)
- [`Cache-Control#max-age`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-age)
- [`Cache-Control#must-revalidate`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#must-revalidate)