### PR TITLE
Let Dependabot handle yarn workspace updates natively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,3 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-
-  - package-ecosystem: "npm"
-    open-pull-requests-limit: 2
-    directory: "/cli"
-    schedule:
-      interval: "weekly"
-      day: "monday"


### PR DESCRIPTION
Dependabot should know about yarn workspaces and handle updates to those correctly. Because the `cli` folder was handled as a top-level yarn project, PRs to that workspace did not include updates to the lockfile (which lives a directory up, and Dependabot doesn't check there).