### PR TITLE
Extract package names from some URLs

### DIFF
--- a/pages/api/jump.handler.ts
+++ b/pages/api/jump.handler.ts
@@ -8,11 +8,12 @@ const handler: NextApiHandler = async (req, res) => {
   const to = typeof req.query.to === "string" ? req.query.to : "";
 
   if (to) {
-    const [packageName, destination] = to
+    const [rawPackageName, destination] = to
       .split(" ")
       .filter((chunk) => chunk.length);
+
     const resolvedDestination = await resolveDestination(
-      packageName ?? "",
+      rawPackageName ?? "",
       destination,
     );
 

--- a/pages/api/jump.handler.ts
+++ b/pages/api/jump.handler.ts
@@ -7,14 +7,14 @@ const handler: NextApiHandler = async (req, res) => {
 
   const to = typeof req.query.to === "string" ? req.query.to : "";
 
-  if (to) {
-    const [rawPackageName, destination] = to
-      .split(" ")
-      .filter((chunk) => chunk.length);
+  const [rawPackageName, rawDestination] = to
+    .split(" ")
+    .filter((chunk) => chunk.length);
 
+  if (rawPackageName) {
     const resolvedDestination = await resolveDestination(
-      rawPackageName ?? "",
-      destination,
+      rawPackageName,
+      rawDestination,
     );
 
     if (resolvedDestination.outcome === "success") {

--- a/pages/shared/destinations.ts
+++ b/pages/shared/destinations.ts
@@ -302,9 +302,9 @@ export const resolveDestination = async (
     );
 
   try {
-    const url = await destinationConfigByKeyword[
-      rawDestination[0] ?? ""
-    ]?.generateUrl(packageName);
+    const url = await destinationConfigByKeyword[rawDestination]?.generateUrl(
+      packageName,
+    );
     if (!url) {
       throw new Error("Unexpected empty URL");
     }

--- a/pages/shared/destinations.ts
+++ b/pages/shared/destinations.ts
@@ -288,9 +288,19 @@ for (const destinationConfig of destinationConfigs) {
 }
 
 export const resolveDestination = async (
-  packageName: string,
+  rawPackageName: string,
   destinationKeyword = "",
 ): Promise<ResolvedDestination> => {
+  const packageName = rawPackageName
+    .replace("https://www.npmjs.com/package/", "") // https://www.npmjs.com/package/@types/react-dom
+    .replace(/\?activeTab=\w+$/, "") // https://www.npmjs.com/package/@types/react-dom?activeTab=versions
+    .replace(/\/v\/[\w.-]+/, "") // https://www.npmjs.com/package/@types/react-dom/v/18.0.9
+    .replace("https://yarnpkg.com/package/", "") // https://yarnpkg.com/package/@types/react-dom
+    .replace(
+      /^https:\/\/unpkg.com\/browse\/(@?[\w.-]+(\/[\w.-]+)?)@([\w.-]+)\/$/, // https://unpkg.com/browse/@types/react-dom@18.0.9/
+      "$1",
+    );
+
   try {
     const url = await destinationConfigByKeyword[
       destinationKeyword
@@ -306,7 +316,7 @@ export const resolveDestination = async (
   } catch {
     return {
       outcome: "success",
-      url: (await destinationConfigByKeyword[""]!.generateUrl(packageName))!,
+      url: (await destinationConfigByKeyword[""]!.generateUrl(rawPackageName))!,
     };
   }
 };

--- a/pages/shared/destinations.ts
+++ b/pages/shared/destinations.ts
@@ -289,7 +289,7 @@ for (const destinationConfig of destinationConfigs) {
 
 export const resolveDestination = async (
   rawPackageName: string,
-  destinationKeyword = "",
+  rawDestination = "",
 ): Promise<ResolvedDestination> => {
   const packageName = rawPackageName
     .replace("https://www.npmjs.com/package/", "") // https://www.npmjs.com/package/@types/react-dom
@@ -303,7 +303,7 @@ export const resolveDestination = async (
 
   try {
     const url = await destinationConfigByKeyword[
-      destinationKeyword
+      rawDestination[0] ?? ""
     ]?.generateUrl(packageName);
     if (!url) {
       throw new Error("Unexpected empty URL");


### PR DESCRIPTION
Simplifies recursive usage of `njt`. Example jump from unpkg to yarn:

**Before**

```txt
⌨️ njt @types/react-dom u
↓
🐸 https://unpkg.com/browse/@types/react-dom@18.0.9/

⌨️ cmd+L (or ctrl+L) to focus on the address bar
⌨️ select and remove "https://unpkg.com/browse/"
⌨️ prepend "njt " (or "n ")
⌨️ select and remove "@18.0.9/"
⌨️ append " y"
⌨️ press enter
↓
🐸 https://yarnpkg.com/package/@types/react-dom
```

**After**

```txt
⌨️ njt @types/react-dom u
↓
🐸 https://unpkg.com/browse/@types/react-dom@18.0.9/

⌨️ cmd+L (or ctrl+L) to focus on the address bar
⌨️ prepend "njt " (or "n ")
⌨️ append " y"
⌨️ press enter
↓
🐸 https://yarnpkg.com/package/@types/react-dom
```
