### PR TITLE
Update Prettier to 3.0.0-alpha.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint-staged": "13.2.1",
     "markdownlint-cli": "0.33.0",
     "npm-run-all": "4.1.5",
-    "prettier": "3.0.0-alpha.6",
+    "prettier": "3.0.0-alpha.10",
     "prettier-plugin-packagejson": "2.4.3",
     "prettier-plugin-sh": "0.12.8",
     "typescript": "5.0.4"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lint-staged": "13.2.1",
     "markdownlint-cli": "0.33.0",
     "npm-run-all": "4.1.5",
-    "prettier": "3.0.0-alpha.10",
+    "prettier": "3.0.0-alpha.11",
     "prettier-plugin-packagejson": "2.4.3",
     "prettier-plugin-sh": "0.12.8",
     "typescript": "5.0.4"

--- a/pages/_app.page/page-layout.tsx
+++ b/pages/_app.page/page-layout.tsx
@@ -7,8 +7,13 @@ import { ExternalLink } from "../shared/external-link";
 const base = css`
   body {
     color: #24292e;
-    font-family: "-apple-system", BlinkMacSystemFont, Avenir Next, Avenir,
-      Helvetica, sans-serif;
+    font-family:
+      "-apple-system",
+      BlinkMacSystemFont,
+      Avenir Next,
+      Avenir,
+      Helvetica,
+      sans-serif;
     margin: 0;
     line-height: 1.4em;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,12 +3365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.0-alpha.10":
-  version: 3.0.0-alpha.10
-  resolution: "prettier@npm:3.0.0-alpha.10"
+"prettier@npm:3.0.0-alpha.11":
+  version: 3.0.0-alpha.11
+  resolution: "prettier@npm:3.0.0-alpha.11"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 82da8c7cae3ab22f7dee67c31f69c2796e10ed71ae6d6c5fe42fa2f07c979ec0c7b152350ccb546a20738d7e5fd27c8482fc66ca3632589ff1a9ba510693eee4
+  checksum: f2f19edc4c677aba0ef599cd427fc4beffc84d675e1cc4d234dd54f8154c215707a07e015840368bc2ec4c8dee4741532f585628142f69bfe33f29e17d7692aa
   languageName: node
   linkType: hard
 
@@ -3624,7 +3624,7 @@ __metadata:
     markdownlint-cli: "npm:0.33.0"
     next: "npm:13.3.1"
     npm-run-all: "npm:4.1.5"
-    prettier: "npm:3.0.0-alpha.10"
+    prettier: "npm:3.0.0-alpha.11"
     prettier-plugin-packagejson: "npm:2.4.3"
     prettier-plugin-sh: "npm:0.12.8"
     react: "npm:18.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3365,12 +3365,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.0.0-alpha.6":
-  version: 3.0.0-alpha.6
-  resolution: "prettier@npm:3.0.0-alpha.6"
+"prettier@npm:3.0.0-alpha.10":
+  version: 3.0.0-alpha.10
+  resolution: "prettier@npm:3.0.0-alpha.10"
   bin:
     prettier: bin/prettier.cjs
-  checksum: bf675dafd551d58db6492af01bc52a212f41ee8666365916b503088b2764a72bbf57bc45bf1752d150a099d06d936bf3fbf5636b8bbb273677eebebf4c2b80a6
+  checksum: 82da8c7cae3ab22f7dee67c31f69c2796e10ed71ae6d6c5fe42fa2f07c979ec0c7b152350ccb546a20738d7e5fd27c8482fc66ca3632589ff1a9ba510693eee4
   languageName: node
   linkType: hard
 
@@ -3624,7 +3624,7 @@ __metadata:
     markdownlint-cli: "npm:0.33.0"
     next: "npm:13.3.1"
     npm-run-all: "npm:4.1.5"
-    prettier: "npm:3.0.0-alpha.6"
+    prettier: "npm:3.0.0-alpha.10"
     prettier-plugin-packagejson: "npm:2.4.3"
     prettier-plugin-sh: "npm:0.12.8"
     react: "npm:18.2.0"


### PR DESCRIPTION
At the moment, this PR demonstrates what happens after upgrading Prettier from 3.0.0-alpha.6 to 3.0.0-alpha.10. See CI output for error details. Upstream issue: https://github.com/prettier/prettier/issues/14753
