### PR TITLE
Improve page speed metrics

### DIFF
--- a/app/layout/page-layout.tsx
+++ b/app/layout/page-layout.tsx
@@ -1,6 +1,7 @@
 import type * as React from "react";
 
 import { ExternalLink } from "../shared/external-link";
+import { nbsp } from "../shared/nbsp";
 
 export function PageLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -12,7 +13,7 @@ export function PageLayout({ children }: { children: React.ReactNode }) {
         <h1 className="text-center text-[48px] leading-[1.4em] font-bold">
           🐸 njt 🐸
         </h1>
-        <div className="text-center font-bold">🐸 npm jump to&nbsp; 🐸</div>
+        <div className="text-center font-bold">🐸 npm jump to{nbsp} 🐸</div>
         <div className="mx-auto mt-2.5 text-center *:mx-2">
           <ExternalLink href="https://github.com/kachkaev/njt">
             github

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { Example } from "./page/example";
 import { InputForm } from "./page/input-form";
 import { cn } from "./shared/cn";
 import { ExternalLink } from "./shared/external-link";
+import { nbsp } from "./shared/nbsp";
 
 function H2({ children }: { children: React.ReactNode }) {
   return <h2 className="mt-12 text-[1em] font-bold">{children}</h2>;
@@ -143,9 +144,9 @@ export default function Page() {
       <H2>More!</H2>
       <p>
         <code>njt</code> gives you an even bigger productivity boost when
-        integrated into browser or&nbsp;terminal. See instructions in{" "}
+        integrated into browser or{nbsp}terminal. See instructions in{" "}
         <ExternalLink href="https://github.com/kachkaev/njt/blob/main/README.md#getting-njt">
-          GitHub&nbsp;repo’s&nbsp;README
+          GitHub{nbsp}repo’s{nbsp}README
         </ExternalLink>
         .
       </p>
@@ -155,9 +156,9 @@ export default function Page() {
           Alexander Kachkaev
         </ExternalLink>{" "}
         using <ExternalLink href="https://nextjs.org">Next.js</ExternalLink>,
-        hosted&nbsp;by&nbsp;
+        hosted{nbsp}by{nbsp}
         <ExternalLink href="https://vercel.com">Vercel</ExternalLink>
-        &nbsp;💚
+        {nbsp}💚
       </p>
     </>
   );

--- a/app/page/available-destinations.tsx
+++ b/app/page/available-destinations.tsx
@@ -2,6 +2,7 @@ import type * as React from "react";
 
 import { cn } from "../shared/cn";
 import { ExternalLink } from "../shared/external-link";
+import { nbsp } from "../shared/nbsp";
 import { ClickableCode } from "./clickable-code";
 
 function Keyword({
@@ -60,8 +61,8 @@ export function AvailableDestinations({
       info: (
         <>
           homepage (aliased as <Keyword onClick={handleKeywordClick}>w</Keyword>{" "}
-          for&nbsp;website or <Keyword onClick={handleKeywordClick}>d</Keyword>{" "}
-          for&nbsp;docs)
+          for{nbsp}website or <Keyword onClick={handleKeywordClick}>d</Keyword>{" "}
+          for{nbsp}docs)
         </>
       ),
     },
@@ -82,7 +83,7 @@ export function AvailableDestinations({
       info: (
         <>
           pull requests (aliased as{" "}
-          <Keyword onClick={handleKeywordClick}>m</Keyword> for&nbsp;merge
+          <Keyword onClick={handleKeywordClick}>m</Keyword> for{nbsp}merge
           requests)
         </>
       ),
@@ -95,8 +96,8 @@ export function AvailableDestinations({
       keywords: ["s"],
       info: (
         <>
-          source (often same as repository root, but can be
-          its&nbsp;subdirectory in&nbsp;case of a&nbsp;monorepo)
+          source (often same as repository root, but can be its{nbsp}
+          subdirectory in{nbsp}case of a{nbsp}monorepo)
         </>
       ),
     },
@@ -166,7 +167,8 @@ export function AvailableDestinations({
       <p>
         Omitting the destination or entering an non-existing one takes you to
         the package page on <ExternalLink href="https://www.npmjs.com" /> as if
-        you used&nbsp;<Keyword onClick={handleKeywordClick}>n</Keyword>.
+        you used{nbsp}
+        <Keyword onClick={handleKeywordClick}>n</Keyword>.
       </p>
     </>
   );

--- a/app/shared/nbsp.ts
+++ b/app/shared/nbsp.ts
@@ -1,12 +1,24 @@
 /**
  * A non-breaking space, to be used as `{nbsp}` in JSX.
  *
- * `&nbsp;` looks nicer, but cannot be used: Turbopack’s server-side JSX
- * transform drops the leading space of any text node that contains an HTML
- * entity, while the client-side one keeps it. Text such as
- * `<code>njt</code> gives you&nbsp;…` thus renders as `njtgives you` in the
- * prerendered HTML and as `njt gives you` after hydration, which React reports
- * as a hydration mismatch and recovers from by re-rendering the whole tree on
- * the client (https://react.dev/errors/418).
+ * `&nbsp;` looks nicer, but cannot be used: SWC drops the leading space of any
+ * JSX text node that also contains an HTML entity, so
+ * `<code>njt</code> gives you&nbsp;…` compiles down to `njtgives you`.
+ *
+ * The bug is https://github.com/swc-project/swc/issues/11541, fixed by
+ * https://github.com/swc-project/swc/pull/11568 and released in `swc_core`
+ * 57.0.1. Next.js still pins 57.0.0 (the last release before that fix), which
+ * is why the bundled `@next/swc` binary keeps reproducing it – see
+ * https://github.com/swc-project/swc/issues/12018 for the same report against
+ * Next.js itself.
+ *
+ * On top of the missing space, `reactCompiler` turns this into a hydration
+ * mismatch: client components go through Babel, which gets the whitespace
+ * right, while the server render stays on SWC and does not. React reacts to
+ * the two disagreeing by throwing away the prerendered HTML and rendering the
+ * whole tree client-side (https://react.dev/errors/418), which is expensive.
+ *
+ * `{" "}` is an equally good workaround, but Prettier collapses it back into a
+ * plain space, taking the fix with it.
  */
 export const nbsp = "\u00A0";

--- a/app/shared/nbsp.ts
+++ b/app/shared/nbsp.ts
@@ -1,0 +1,12 @@
+/**
+ * A non-breaking space, to be used as `{nbsp}` in JSX.
+ *
+ * `&nbsp;` looks nicer, but cannot be used: Turbopack’s server-side JSX
+ * transform drops the leading space of any text node that contains an HTML
+ * entity, while the client-side one keeps it. Text such as
+ * `<code>njt</code> gives you&nbsp;…` thus renders as `njtgives you` in the
+ * prerendered HTML and as `njt gives you` after hydration, which React reports
+ * as a hydration mismatch and recovers from by re-rendering the whole tree on
+ * the client (https://react.dev/errors/418).
+ */
+export const nbsp = "\u00A0";

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,12 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  /*
+   * The whole site is a single ~11 kB stylesheet, so putting it into the
+   * document removes the only render-blocking request on the critical path.
+   */
+  experimental: { inlineCss: true },
+
   productionBrowserSourceMaps: true,
 
   reactCompiler: true,

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /*
-   * The whole site is a single ~11 kB stylesheet, so putting it into the
-   * document removes the only render-blocking request on the critical path.
-   */
-  experimental: { inlineCss: true },
+  experimental: {
+    // One network request fewer, which is worth it for as little CSS as we have
+    inlineCss: true,
+  },
 
   productionBrowserSourceMaps: true,
 


### PR DESCRIPTION
This PR fixes a hydration mismatch that was costing the home page its mobile Speed Index, and takes the stylesheet off the critical path.

- Turbopack’s server-side JSX transform drops the leading space of any text node containing an HTML entity, while the client-side one keeps it. Three text nodes were affected, so the prerendered HTML read `njtgives you`, `npmjs.comas if` and `m for merge` — and React, seeing the mismatch ([#418](https://react.dev/errors/418)), discarded the server HTML and re-rendered the whole tree on the client. `&nbsp;` is therefore replaced with a `{nbsp}` constant; `{" "}` also works, but Prettier undoes it.
- `experimental.inlineCss` puts the ~11 kB stylesheet into the document, removing the only render-blocking request.

Lighthouse against the preview deployment, compared with the same run on `njt.vercel.app`:

| | mobile | desktop |
| --- | --- | --- |
| performance | 97 → 100 | 100 → 100 |
| best practices | 96 → 100 | 96 → 100 |
| speed index | 4.3 s → 1.1 s | 0.5 s → 0.4 s |
| largest contentful paint | 2.0 s → 1.1 s | 0.4 s → 0.3 s |
| total blocking time | 34 ms → 9 ms | 0 ms → 0 ms |

Two audits stay red on purpose. Accessibility is still 96 because of `link-in-text-block`, which is for a separate PR. `legacy-javascript` and `unused-javascript` are Next.js baseline costs — `polyfill-module` is an unconditional import in `next/dist/client/app-globals.js`, and neither browserslist nor any config flag drops it. Preview deployments also report SEO 60 rather than 100, purely because Vercel serves them with `x-robots-tag: noindex`.