### PR TITLE
Add robots.txt and sitemap.xml

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,13 +6,7 @@ import type * as React from "react";
 
 import { JsClassSwitcher } from "./layout/js-class-switcher";
 import { PageLayout } from "./layout/page-layout";
-
-function getBaseUrl() {
-  const hostname = process.env["NEXT_PUBLIC_VERCEL_URL"] ?? "njt.vercel.app";
-  const protocol = hostname.split(":")[0] === "localhost" ? "http" : "https";
-
-  return `${protocol}://${hostname}`;
-}
+import { getBaseUrl } from "./shared/base-url";
 
 const title = "njt (npm jump to)";
 const description = "a quick navigation tool for npm packages";

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+import { getBaseUrl } from "./shared/base-url";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      // A redirect endpoint rather than a page: following it just bounces the
+      // crawler off-site, and every `to` spells a separate URL to crawl
+      disallow: "/jump",
+    },
+    sitemap: `${getBaseUrl()}/sitemap.xml`,
+  };
+}

--- a/app/shared/base-url.ts
+++ b/app/shared/base-url.ts
@@ -1,0 +1,14 @@
+/**
+ * The origin the site is served from, used to make `og:image` and friends
+ * absolute, and to spell out the URLs in robots.txt and sitemap.xml.
+ *
+ * On preview deployments this resolves to the deployment’s own hostname, which
+ * is what we want: Vercel serves previews with `x-robots-tag: noindex`, so the
+ * URLs they advertise never reach an index.
+ */
+export function getBaseUrl(): string {
+  const hostname = process.env["NEXT_PUBLIC_VERCEL_URL"] ?? "njt.vercel.app";
+  const protocol = hostname.split(":")[0] === "localhost" ? "http" : "https";
+
+  return `${protocol}://${hostname}`;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+import { getBaseUrl } from "./shared/base-url";
+
+/**
+ * The home page is the only thing worth indexing, so this exists mostly to give
+ * robots.txt something to point at. `lastModified` is left out on purpose: a
+ * build-time date would change on every deploy without the page having changed.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [{ url: `${getBaseUrl()}/` }];
+}

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,6 +8,15 @@ export default defineConfig([
   }),
 
   {
+    // Next’s metadata route conventions call for a default export. The upstream
+    // override covers the `.tsx` route files, but not these two.
+    files: ["app/{robots,sitemap}.ts"],
+    rules: {
+      "import/no-default-export": "off",
+    },
+  },
+
+  {
     files: ["cli/**/*.js"],
     extends: [typescriptEslint.configs.disableTypeChecked],
     rules: {


### PR DESCRIPTION
This PR adds the two metadata routes, both prerendered as static.

`robots.txt` allows everything except `/jump`, which is a redirect endpoint rather than a page — crawling it just bounces the crawler off-site, and every `to` value spells a separate URL. The Search Console verification file in `public/` stays reachable under `Allow: /`.

`sitemap.xml` lists the home page alone, which is all there is to index; it mostly exists to give `robots.txt` something to point at. `lastModified` is deliberately omitted — a build-time date would churn on every deploy without the page having changed.

Two incidental bits:

- `getBaseUrl` moves from `app/layout.tsx` to `app/shared/base-url.ts`, so `metadataBase`, `robots.txt` and `sitemap.xml` cannot drift apart. Verified that `og:image` still resolves to `https://njt.vercel.app/og-image.png`.
- `eslint.config.ts` turns off `import/no-default-export` for these two files. Next’s metadata route conventions require a default export, and the upstream override in `@kachkaev/eslint-config-next` only lists the `.tsx` route files (`main.ts:132`) — might be worth widening there.

On preview deployments both files advertise the preview hostname, which is harmless: Vercel serves previews with `x-robots-tag: noindex`.

Verified locally against a production build:

```
User-Agent: *
Allow: /
Disallow: /jump

Sitemap: https://njt.vercel.app/sitemap.xml
```