### PR TITLE
Add a weekly repo-dive report workflow

### DIFF
--- a/.github/workflows/repo-dive.yaml
+++ b/.github/workflows/repo-dive.yaml
@@ -7,6 +7,11 @@ on:
   schedule:
     - cron: "27 5 * * 1" # weekly, Monday morning
   workflow_dispatch:
+  # Temporary, to test-drive the workflow right in the PR that adds it:
+  # schedule and workflow_dispatch only fire from the default branch
+  pull_request:
+    paths:
+      - .github/workflows/repo-dive.yaml
 
 permissions:
   contents: read

--- a/.github/workflows/repo-dive.yaml
+++ b/.github/workflows/repo-dive.yaml
@@ -7,11 +7,6 @@ on:
   schedule:
     - cron: "27 5 * * 1" # weekly, Monday morning
   workflow_dispatch:
-  # Temporary, to test-drive the workflow right in the PR that adds it:
-  # schedule and workflow_dispatch only fire from the default branch
-  pull_request:
-    paths:
-      - .github/workflows/repo-dive.yaml
 
 permissions:
   contents: read

--- a/.github/workflows/repo-dive.yaml
+++ b/.github/workflows/repo-dive.yaml
@@ -1,0 +1,30 @@
+name: repo-dive
+
+# Generates https://github.com/kachkaev/repo-dive report for this repository
+# and uploads it as a workflow artifact, viewable straight from the run page
+
+on:
+  schedule:
+    - cron: "27 5 * * 1" # weekly, Monday morning
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# One analysis at a time, so parallel runs don't redo each other's work
+concurrency:
+  group: repo-dive
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Generate report
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # the whole history is the whole point
+
+      - name: Run repo-dive
+        uses: kachkaev/repo-dive@main


### PR DESCRIPTION
This PR dogfoods the new [repo-dive GitHub Action](https://github.com/kachkaev/repo-dive/blob/main/docs/github-action.md): a weekly (or manually dispatched) run scans the full history, caches the catalog for incremental refreshes and uploads the self-contained HTML report as an artifact viewable straight from the run page.

Test-driven right in this PR via a temporary `pull_request` trigger (added in 5e5dfc2, reverted in f71fe2b once proven): [the run](https://github.com/kachkaev/njt/actions/runs/31228921367) scanned all 1363 commits, saved the catalog cache and uploaded a 1.6 MB report in 2m33s.