### PR TITLE
Stop Renovate from pinning cli runtime dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>kachkaev/reusable-stuff:renovate-preset"]
+  "extends": ["github>kachkaev/reusable-stuff:renovate-preset"],
+  "packageRules": [
+    {
+      "description": "`cli` is published to npm, so its runtime `dependencies` are what consumers resolve against. The shared preset pins every range, which would lock dependents to one exact version and clash with anything else in their tree that needs a different one. `replace` keeps the caret ranges and only opens a PR when a release falls outside them. Everything else stays pinned: the root app is private, and `cli`’s `devDependencies` never reach consumers.",
+      "matchFileNames": ["cli/package.json"],
+      "matchDepTypes": ["dependencies"],
+      "rangeStrategy": "replace"
+    }
+  ]
 }


### PR DESCRIPTION
This PR overrides the shared preset's global `rangeStrategy: "pin"` for `cli/package.json` → `dependencies` only, so the caret ranges consumers resolve against survive. Everything else in the repo — the root app, `cli`'s `devDependencies`, GitHub Actions — stays pinned, so #1282 should shrink rather than disappear.